### PR TITLE
[health-check] Better health check to prevent against lag

### DIFF
--- a/src/main/java/com/airbnb/airpal/core/health/PrestoHealthCheck.java
+++ b/src/main/java/com/airbnb/airpal/core/health/PrestoHealthCheck.java
@@ -8,8 +8,12 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
+import com.google.inject.name.Named;
 
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static com.airbnb.airpal.presto.QueryRunner.QueryRunnerFactory;
@@ -18,34 +22,47 @@ public class PrestoHealthCheck extends HealthCheck
 {
     private static final String HEALTH_CHECK_QUERY = "SELECT 1";
 
-    private final Supplier<Result> resultSupplier;
+    private final Supplier<Future<Result>> resultSupplier;
 
     @Inject
-    public PrestoHealthCheck(final QueryRunnerFactory queryRunnerFactory)
+    public PrestoHealthCheck(
+            final QueryRunnerFactory queryRunnerFactory,
+            @Named("presto") final ExecutorService executorService)
     {
-        Supplier<Result> baseSupplier = new Supplier<Result>()
+        // To prevent a lagging Presto health check from freezing Airpal, by blocking a large
+        // number of health check threads, we have the supplier return a Future<Result>. This
+        // way, the Future is immediately memoized and all calls will be successful if the
+        // future resolved successfully.
+        Supplier<Future<Result>> baseSupplier = new Supplier<Future<Result>>()
         {
             @Override
-            public Result get()
+            public Future<Result> get()
             {
-                final List<Object> invalidValue = ImmutableList.of((Object) new Integer(-1));
-                List<Object> result;
+                return executorService.submit(new Callable<Result>() {
+                    @Override
+                    public Result call()
+                            throws Exception
+                    {
+                        final List<Object> invalidValue = ImmutableList.of((Object) new Integer(-1));
+                        List<Object> result;
 
-                try (StatementClient client = queryRunnerFactory.create().startInternalQuery(HEALTH_CHECK_QUERY)) {
-                    while (client.isValid() && !Thread.currentThread().isInterrupted()) {
-                        Iterable<List<Object>> results = client.current().getData();
-                        if (results != null) {
-                            result = Iterables.getFirst(results, invalidValue);
-                            assert(result != null);
-                            assert(result.size() == 1);
-                            assert(result.get(0) == 1);
+                        try (StatementClient client = queryRunnerFactory.create().startInternalQuery(HEALTH_CHECK_QUERY)) {
+                            while (client.isValid() && !Thread.currentThread().isInterrupted()) {
+                                Iterable<List<Object>> results = client.current().getData();
+                                if (results != null) {
+                                    result = Iterables.getFirst(results, invalidValue);
+                                    assert(result != null);
+                                    assert(result.size() == 1);
+                                    assert(result.get(0) == 1);
+                                }
+                                client.advance();
+                            }
+                            return Result.healthy();
+                        } catch (Exception e) {
+                            throw Throwables.propagate(e);
                         }
-                        client.advance();
                     }
-                    return Result.healthy();
-                } catch (Exception e) {
-                    throw Throwables.propagate(e);
-                }
+                });
             }
         };
 
@@ -55,6 +72,8 @@ public class PrestoHealthCheck extends HealthCheck
     @Override
     protected Result check() throws Exception
     {
-        return resultSupplier.get();
+        // Wait at most 5 seconds for the future to resolve, so that we don't block too many
+        // threads awaiting the result of this check.
+        return resultSupplier.get().get(5, TimeUnit.SECONDS);
     }
 }

--- a/src/main/java/com/airbnb/airpal/modules/AirpalModule.java
+++ b/src/main/java/com/airbnb/airpal/modules/AirpalModule.java
@@ -218,7 +218,7 @@ public class AirpalModule extends AbstractModule
     @Singleton
     @Provides
     public SchemaCache provideSchemaCache(QueryRunnerFactory queryRunnerFactory,
-                                          @Named("completer") ExecutorService executorService)
+                                          @Named("presto") ExecutorService executorService)
     {
         final SchemaCache cache = new SchemaCache(queryRunnerFactory, executorService);
         cache.populateCache(config.getPrestoCatalog());
@@ -229,7 +229,7 @@ public class AirpalModule extends AbstractModule
     @Singleton
     @Provides
     public ColumnCache provideColumnCache(QueryRunnerFactory queryRunnerFactory,
-                                          @Named("completer") ExecutorService executorService)
+                                          @Named("presto") ExecutorService executorService)
     {
         return new ColumnCache(queryRunnerFactory,
                                new Duration(5, TimeUnit.MINUTES),
@@ -240,7 +240,7 @@ public class AirpalModule extends AbstractModule
     @Singleton
     @Provides
     public PreviewTableCache providePreviewTableCache(QueryRunnerFactory queryRunnerFactory,
-                                                      @Named("completer") ExecutorService executorService)
+                                                      @Named("presto") ExecutorService executorService)
     {
         return new PreviewTableCache(queryRunnerFactory,
                                      new Duration(20, TimeUnit.MINUTES),
@@ -257,11 +257,11 @@ public class AirpalModule extends AbstractModule
     }
 
     @Singleton
-    @Named("completer")
+    @Named("presto")
     @Provides
     public ExecutorService provideCompleterExecutorService()
     {
-        return Executors.newCachedThreadPool(SchemaCache.daemonThreadsNamed("completer-%d"));
+        return Executors.newCachedThreadPool(SchemaCache.daemonThreadsNamed("presto-%d"));
     }
 
     @Singleton
@@ -312,7 +312,7 @@ public class AirpalModule extends AbstractModule
 
     @Singleton
     @Provides
-    public HiveTableUpdatedCache provideHiveTableUpdatedCache(@Named("completer") ExecutorService executorService)
+    public HiveTableUpdatedCache provideHiveTableUpdatedCache(@Named("presto") ExecutorService executorService)
     {
         AirpalConfiguration.HiveMetastoreConfiguration metastoreConfiguration = config.getMetaStoreConfiguration();
 


### PR DESCRIPTION
This PR updates the presto health check so that in the case where the response lags, for whatever reason, we don't block indefinitely. This can also cause the health check to fail in the case of a lagging response.
