### PR TITLE
Use default catalog in TablesResource

### DIFF
--- a/src/main/java/com/airbnb/airpal/modules/AirpalModule.java
+++ b/src/main/java/com/airbnb/airpal/modules/AirpalModule.java
@@ -118,6 +118,14 @@ public class AirpalModule extends AbstractModule
         return config.getPrestoCoordinator();
     }
 
+    @Singleton
+    @Named("default-catalog")
+    @Provides
+    public String provideDefaultCatalog()
+    {
+        return config.getPrestoCatalog();
+    }
+
     @Provides
     @Singleton
     public ClientSessionFactory provideClientSessionFactory(@Named("coordinator-uri") Provider<URI> uriProvider)


### PR DESCRIPTION
This PR uses the configured default catalog in `TablesResource`. An important future TODO is make all `TablesResource` endpoints accept a `catalog` parameter.

/cc @airbnb/di @stefanvermaas 
