### PR TITLE
[sse] Be pessimistic about exceptions in SSE

### DIFF
--- a/src/main/java/com/airbnb/airpal/resources/sse/SSEEventSource.java
+++ b/src/main/java/com/airbnb/airpal/resources/sse/SSEEventSource.java
@@ -41,6 +41,7 @@ public class SSEEventSource implements EventSource
             }
             catch (IOException e) {
                 log.error("Could not send data to SSEEventSource", e);
+                jobUpdateToSSERelay.removeListener(this);
             }
         } else {
             log.error("Emitter was closed, could not emit message!");


### PR DESCRIPTION
This Exception is usually triggered when a client refreshes or closes/reopens airpal. For some reason, Jetty is not notified of a proper close, so the normal method of removing the listener doesn't work. Instead, we choose to be pessimistic about this exception, and assume that the connection is closed. When this happens, the browser should automatically attempt to reconnect.

/cc @stefanvermaas 
