### PR TITLE
[active-query-store] Add an active query store

### DIFF
--- a/src/main/java/com/airbnb/airpal/core/execution/InputReferenceExtractor.java
+++ b/src/main/java/com/airbnb/airpal/core/execution/InputReferenceExtractor.java
@@ -21,8 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static java.lang.String.format;
-
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class InputReferenceExtractor
@@ -126,7 +124,6 @@ public class InputReferenceExtractor
     @Override
     protected CatalogSchemaContext visitNode(Node node, CatalogSchemaContext context)
     {
-        System.out.println(format("Inspecting Node: %s :: Context: %s", node, context));
         return context;
     }
 

--- a/src/main/java/com/airbnb/airpal/core/store/ActiveJobsStore.java
+++ b/src/main/java/com/airbnb/airpal/core/store/ActiveJobsStore.java
@@ -1,0 +1,31 @@
+package com.airbnb.airpal.core.store;
+
+import com.airbnb.airpal.api.Job;
+import com.airbnb.airpal.core.AirpalUser;
+
+import java.util.Set;
+
+/**
+ * A store for currently running jobs.
+ */
+public interface ActiveJobsStore
+{
+    /**
+     * Get all running jobs for the specified user.
+     * @param user The user to retrieve jobs for.
+     * @return All currently running jobs for this user.
+     */
+    public Set<Job> getJobsForUser(AirpalUser user);
+
+    /**
+     * Mark a job as having started.
+     * @param job The job that has started.
+     */
+    public void jobStarted(Job job);
+
+    /**
+     * Mark a job as having finished.
+     * @param job The job that has finished.
+     */
+    public void jobFinished(Job job);
+}

--- a/src/main/java/com/airbnb/airpal/core/store/InMemoryActiveJobsStore.java
+++ b/src/main/java/com/airbnb/airpal/core/store/InMemoryActiveJobsStore.java
@@ -1,0 +1,50 @@
+package com.airbnb.airpal.core.store;
+
+import com.airbnb.airpal.api.Job;
+import com.airbnb.airpal.core.AirpalUser;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class InMemoryActiveJobsStore implements ActiveJobsStore
+{
+    private ConcurrentMap<String, Set<Job>> activeJobs = new ConcurrentHashMap<>();
+
+    @Override
+    public Set<Job> getJobsForUser(AirpalUser user)
+    {
+        if (!activeJobs.containsKey(user.getUserName())) {
+            return Collections.emptySet();
+        }
+
+        return ImmutableSet.copyOf(activeJobs.get(user.getUserName()));
+    }
+
+    @Override
+    public void jobStarted(Job job)
+    {
+        Set<Job> jobsForUser = activeJobs.get(job.getUser());
+
+        if (jobsForUser == null) {
+            jobsForUser = Collections.newSetFromMap(new ConcurrentHashMap<Job, Boolean>());
+            activeJobs.putIfAbsent(job.getUser(), jobsForUser);
+        }
+
+        activeJobs.get(job.getUser()).add(job);
+    }
+
+    @Override
+    public void jobFinished(Job job)
+    {
+        Set<Job> jobsForUser = activeJobs.get(job.getUser());
+
+        if (jobsForUser == null) {
+            return;
+        }
+
+        jobsForUser.remove(job);
+    }
+}

--- a/src/main/java/com/airbnb/airpal/modules/AirpalModule.java
+++ b/src/main/java/com/airbnb/airpal/modules/AirpalModule.java
@@ -7,7 +7,9 @@ import com.airbnb.airpal.core.PersistentJobOutputFactory;
 import com.airbnb.airpal.core.execution.ExecutionClient;
 import com.airbnb.airpal.core.health.PrestoHealthCheck;
 import com.airbnb.airpal.core.hive.HiveTableUpdatedCache;
+import com.airbnb.airpal.core.store.ActiveJobsStore;
 import com.airbnb.airpal.core.store.CachingUsageStore;
+import com.airbnb.airpal.core.store.InMemoryActiveJobsStore;
 import com.airbnb.airpal.core.store.JobHistoryStore;
 import com.airbnb.airpal.core.store.JobHistoryStoreDAO;
 import com.airbnb.airpal.core.store.QueryStore;
@@ -296,5 +298,12 @@ public class AirpalModule extends AbstractModule
     public AirpalUserFactory provideAirpalUserFactory()
     {
         return new AirpalUserFactory(config.getPrestoSchema(), org.joda.time.Duration.standardMinutes(15), "default");
+    }
+
+    @Provides
+    @Singleton
+    public ActiveJobsStore provideActiveJobsStore()
+    {
+        return new InMemoryActiveJobsStore();
     }
 }


### PR DESCRIPTION
This PR adds an active query store (in memory only, currently) and a resource endpoint for retrieving the active results for a user at: 

```
/api/users/:id/active-queries
```

The results of the endpoint are in the same format as:

```
/api/users/:id/queries
```
