### PR TITLE
Different build settings for NODE_ENV=development

### DIFF
--- a/src/main/resources/assets/gulp/config.js
+++ b/src/main/resources/assets/gulp/config.js
@@ -1,7 +1,10 @@
-var dest = "./build";
+var isDevelopment = process.env.NODE_ENV === 'development';
+var dest = isDevelopment ? "../../../../build/classes/main/assets/build" : "./build";
 var src = './javascripts';
 
 module.exports = {
+  isDevelopment: isDevelopment,
+
   browserSync: {
     proxy: "localhost:8081",
     files: [


### PR DESCRIPTION
For better development experience, when NODE_ENV=development:
1. Don't minify, because it was messing up sourcemaps.
2. Change the output destination of asset building to play better with
   IntelliJ's classmaps, so changes are picked up during local
   development.

The idea is to run:

```
NODE_ENV=development gulp watch
```

from the

```
src/main/resources/assets
```

directory.

Plz to review @stefanvermaas @andykram 
