### PR TITLE
[table-info] Update column info display

### DIFF
--- a/src/main/resources/assets/index.html
+++ b/src/main/resources/assets/index.html
@@ -10,8 +10,9 @@
     <link rel="stylesheet" href="app/stylesheets/vendor/normalize.css">
     <link rel="stylesheet" href="app/stylesheets/bootstrap.min.css">
     <link rel="stylesheet" href="app/stylesheets/plugins/selectize.min.css">
-    <link rel="stylesheet" href="app/stylesheets/themes/airbnb.css">
     <link rel="stylesheet" href="app/stylesheets/themes/default.css">
+    <link rel="stylesheet" href="app/stylesheets/themes/airbnb.css">
+    <link rel="stylesheet" href="app/stylesheets/airpal.css">
 
     <!--[if lt IE 9]>
       <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.6.2/html5shiv.js"></script>

--- a/src/main/resources/assets/javascripts/components/Column.react.js
+++ b/src/main/resources/assets/javascripts/components/Column.react.js
@@ -20,7 +20,7 @@ var Column = React.createClass({
     // Return the template
     return (
       <div className="col-sm-3">
-        <div className="panel panel-default">
+        <div className="panel panel-default panel-compressed">
 
           <div className="panel-body">
             <strong>{this.props.name} </strong> {value}

--- a/src/main/resources/assets/javascripts/components/ColumnsPreview.react.js
+++ b/src/main/resources/assets/javascripts/components/ColumnsPreview.react.js
@@ -46,17 +46,24 @@ var ColumnsPreview = React.createClass({
   _renderColumns: function(collection) {
     var columns;
 
-    // Get all available columns
-    columns = _.map(collection, function(object, idx) {
+    var partitions = _.chain(collection).where({partition: true}).sortBy('name').value(),
+        normalCols = _.chain(collection).where({partition: false}).sortBy('name').value();
 
-      // Capitalize the name of the object
-      var name = this._capitalize(object.name);
+    columns = _.chain(partitions.concat(normalCols)).reduce(function(m, col) {
+      var reuseGroup = (m.length > 0) && (m[m.length - 1].length < 4),
+          group = reuseGroup ? m[m.length - 1] : [],
+          val;
 
-      // Return the template
-      return (
-        <Column key={idx} name={name} type={object.type} />
-      );
-    }.bind(this));
+      group.push(<Column key={col.name} name={col.name} type={col.type} />);
+
+      if (!reuseGroup) {
+        m.push(group);
+      }
+
+      return m;
+    }, []).map(function(col, i) {
+      return (<div className="row" key={'col-row-' + i}>{col}</div>);
+    }).value();
 
     // Render the template
     return (<div>{columns}</div>);

--- a/src/main/resources/assets/javascripts/components/TableInfo.react.js
+++ b/src/main/resources/assets/javascripts/components/TableInfo.react.js
@@ -14,7 +14,9 @@ var TableInfo = React.createClass({
     return (
       <section className="row spaced tables-selector-row">
         <div className="col-sm-12">
-          <TabbedArea defaultActiveKey={1} animation={false}>
+        <div className="panel panel-default panel-container">
+        <div className="panel-body">
+          <TabbedArea defaultActiveKey={1} animation={false} bsStyle={'pills'}>
 
             <TabPane eventKey={1} tab="Columns">
               <ColumnsPreview />
@@ -29,6 +31,8 @@ var TableInfo = React.createClass({
             </TabPane>
 
           </TabbedArea>
+        </div>
+        </div>
         </div>
       </section>
     );

--- a/src/main/resources/assets/stylesheets/airpal.css
+++ b/src/main/resources/assets/stylesheets/airpal.css
@@ -1,0 +1,19 @@
+.panel-compressed {
+  margin-bottom: 10px;
+}
+
+.panel-compressed .panel-body {
+  padding: 4px 6px;
+}
+
+.panel-container {
+}
+
+.panel-container > .panel-body {
+  padding: 6px 15px 0;
+}
+
+.panel-container .panel-body .panel-heading {
+  border-bottom: 1px solid #ddd;
+  padding: 6px 0 6px;
+}


### PR DESCRIPTION
This PR updates the table info display in a few ways:
- Sorts columns alphabetically, and puts partition keys first
- Removes capitalization from column names
- Tweaks visual display to make it a little more intuitive and less padding-y

/to @spikebrehm @stefanvermaas 
