### PR TITLE
Remove updateQuery action & related code

### DIFF
--- a/src/main/resources/assets/javascripts/actions/QueryActions.js
+++ b/src/main/resources/assets/javascripts/actions/QueryActions.js
@@ -15,14 +15,6 @@ module.exports = {
     });
   },
 
-  updateQuery: function(id, data) {
-    AppDispatcher.handleViewAction({
-      type: QueryConstants.UPDATE_QUERY,
-      id: id,
-      data: data
-    });
-  },
-
   destroyQuery: function(id) {
     AppDispatcher.handleViewAction({
       type: QueryConstants.DESTROY_QUERY,
@@ -45,15 +37,6 @@ module.exports = {
     AppDispatcher.handleServerAction({
       type: QueryConstants.RECEIVED_MULTIPLE_QUERIES,
       queries: queries
-    });
-  },
-
-  // Triggered when a query is updated
-  receivedUpdatedQuery: function(id, query) {
-    AppDispatcher.handleServerAction({
-      type: QueryConstants.RECEIVED_UPDATED_QUERY,
-      id: id,
-      query: query
     });
   },
 

--- a/src/main/resources/assets/javascripts/constants/QueryConstants.js
+++ b/src/main/resources/assets/javascripts/constants/QueryConstants.js
@@ -6,12 +6,10 @@ var keyMirror = require('keymirror');
 
 module.exports = keyMirror({
   CREATE_QUERY: null,
-  UPDATE_QUERY: null,
   DESTROY_QUERY: null,
 
   RECEIVED_SINGLE_QUERY: null,
   RECEIVED_MULTIPLE_QUERIES: null,
-  RECEIVED_UPDATED_QUERY: null,
   RECEIVED_DESTROYED_QUERY: null,
 
   FETCH_USER_QUERIES: null

--- a/src/main/resources/assets/javascripts/stores/QueryStore.js
+++ b/src/main/resources/assets/javascripts/stores/QueryStore.js
@@ -43,16 +43,6 @@ QueryStore.dispatchToken = AppDispatcher.register(function(payload) {
       QueryStore.emitChange('change');
       break;
 
-    case QueryConstants.UPDATE_QUERY:
-      QueryApiUtils.updateQuery(action.uuid, action.query);
-      QueryStore.emitChange('change');
-      break;
-
-    case QueryConstants.RECEIVED_UPDATED_QUERY:
-      QueryStore.update(action.uuid, action.query);
-      QueryStore.emitChange('change');
-      break;
-
     default:
       // do nothing
   }

--- a/src/main/resources/assets/javascripts/utils/QueryApiUtils.js
+++ b/src/main/resources/assets/javascripts/utils/QueryApiUtils.js
@@ -57,20 +57,8 @@ module.exports = {
         // TODO: currently the API only returns the uuid, but I also want the
         // name and the description. So we're merging the uuid into the data
         // object
-        var query = _.extend(data, { uuid: uuid });
+        var query = _.extend({}, data, {uuid: uuid});
         QueryActions.receivedQuery(query);
-      }
-    });
-  },
-
-  updateQuery: function(id, data) {
-    $.ajax({
-      type: 'PATCH',
-      url: './api/queries/' + id,
-      data: data,
-
-      success: function(query) {
-        QueryActions.receivedUpdatedQuery(id, query);
       }
     });
   },


### PR DESCRIPTION
It turns out we're not implementing a PATCH for the queries resource,
and we won't be using the `updateQuery` action or related code. Let's
nuke it to simplify things.

@andykram @stefanvermaas 
