### PR TITLE
Move StoreDefaults to BaseStore class

### DIFF
--- a/src/main/resources/assets/javascripts/stores/BaseStore.js
+++ b/src/main/resources/assets/javascripts/stores/BaseStore.js
@@ -1,20 +1,23 @@
 /**
- * StoreDefaults
+ * BaseStore
  */
 
 // Utilities
 var _ = require('lodash');
+var EventEmitter  = require('events').EventEmitter;
 
-var StoreDefaults = {
+class BaseStore extends EventEmitter {
 
-  /* - Defaults ------------------------------------------------------------ */
+  constructor() {
+    /* - Defaults ------------------------------------------------------------ */
 
-  // The collection holds the data for the store
-  collection: [],
+    // The collection holds the data for the store
+    this.collection = [];
 
-  // Defines the default comparator for the collection
-  // @return {String} the uuid of the model
-  comparator: 'uuid',
+    // Defines the default comparator for the collection
+    // @return {String} the uuid of the model
+    this.comparator = 'uuid';
+  }
 
   /* - Selectors ----------------------------------------------------------- */
 
@@ -22,8 +25,8 @@ var StoreDefaults = {
   // if no comparator is given, the default one is used
   // @param options {object} the options for this function
   // @return {array} the collection
-  all: function(options) {
-    if ( this.size() === 0 ) return [];
+  all(options) {
+    if (this.size() === 0) return [];
     options || (options = {})
 
     // Return the sorted collection
@@ -31,19 +34,19 @@ var StoreDefaults = {
       return _.sortBy(this.collection, options.sortBy || this.comparator)
     }
     return this.collection;
-  },
+  }
 
   // Get a specific query from the collection
   // @param {integer} the event uuid
   // @return {object/undefined} the query object
-  get: function(uuid) {
+  get(uuid) {
     return _.find(this.collection, { uuid: uuid });
-  },
+  }
 
   // Filters the collection based on the arguments
   // @param context {Object/Function/Array} the search context
-  where: function(context, options) {
-    if ( _.isEmpty(context) || this.size() === 0 ) return [];
+  where(context, options) {
+    if (_.isEmpty(context) || this.size() === 0) return [];
     options || (options = {})
 
     // Filter the collection
@@ -54,13 +57,13 @@ var StoreDefaults = {
       return _.sortBy(results, options.sortBy || this.comparator);
     }
     return results;
-  },
+  }
 
   // Defines the size of the store collection
   // @return {Integer} the size of the store collection
-  size: function() {
+  size() {
     return _.size(this.collection);
-  },
+  }
 
   /* - Modifiers ----------------------------------------------------------- */
 
@@ -68,7 +71,7 @@ var StoreDefaults = {
   // sure we don't got the object
   // @param models {Object} the model object
   // @return {Object} the store
-  add: function(models, options) {
+  add(models, options) {
     options || (options = {})
 
     // Convert a single object to an array
@@ -78,26 +81,26 @@ var StoreDefaults = {
     // Loop over the array and try to add them to the collection.
     _.each(models, function(model) {
       // Make sure this is a unique item. If there is already a match, fail this.
-      unique = _.find(this.collection, { uuid: model.uuid });
-      if( !_.isUndefined(unique) ) return;
+      var unique = _.find(this.collection, { uuid: model.uuid });
+      if (!_.isUndefined(unique)) return;
 
       // Add the model to the collection
       this.collection.push(model);
 
       // Emit a store create event, unless the silent param is given
-      if ( options.silent ) return this;
+      if (options.silent) return this;
       this.emitChange('add');
     }.bind(this));
 
     // Return this for chaining purpose
     return this;
-  },
+  }
 
   // Updates a model based on the uuid and the new object data
   // @param uuid {String} the uuid of the model
   // @param changedObject {Object} the updated run
   // @return {Object} the run store
-  update: function(uuid, changedObject, options) {
+  update(uuid, changedObject, options) {
     options || (options = {})
 
     // Find the correct entry and update it with the new info
@@ -111,31 +114,31 @@ var StoreDefaults = {
     this.collection.push(model);
 
     // Emit the update event, unless the silent param is given
-    if ( options.silent ) return this;
+    if (options.silent) return this;
     this.emitChange('update');
     return this;
-  },
+  }
 
   /* - Events handlers ----------------------------------------------------- */
 
   // Emit the changes with the eventemitter
-  emitChange: function(eventName, options) {
+  emitChange(eventName, options) {
     this.emit(eventName, options);
-  },
+  }
 
   // Creates an event listener for a specific event
   // @param eventName {string} event name to listen to
   // @param callback {function} event callback
-  addStoreListener: function(eventName, callback) {
+  addStoreListener(eventName, callback) {
     this.on(eventName, callback);
-  },
+  }
 
   // Removes a specific event listener
   // @param eventName {string} event name to remove
   // @param callback {function} event callback
-  removeStoreListener: function(eventName, callback) {
+  removeStoreListener(eventName, callback) {
     this.removeListener(eventName, callback);
   }
-};
+}
 
-module.exports = StoreDefaults;
+module.exports = BaseStore;

--- a/src/main/resources/assets/javascripts/stores/QueryStore.js
+++ b/src/main/resources/assets/javascripts/stores/QueryStore.js
@@ -2,7 +2,7 @@
  * QueryStore
  */
 
-var StoreDefaults   = require('./StoreDefaults');
+var BaseStore   = require('./BaseStore');
 var AppDispatcher   = require('../dispatchers/AppDispatcher');
 var QueryConstants  = require('../constants/QueryConstants');
 var QueryApiUtils   = require('../utils/QueryApiUtils');
@@ -13,16 +13,8 @@ var UserStore = require('./UserStore');
 /* Other constants */
 var UserConstants   = require('../constants/UserConstants');
 
-/* Store helpers */
-var EventEmitter = require('events').EventEmitter;
-var assign = require('object-assign');
-var _ = require('lodash');
-
 /* Query store */
-var QueryStore = assign({}, StoreDefaults, EventEmitter.prototype, {
-
-  // Store extentions
-});
+var QueryStore = new BaseStore();
 
 QueryStore.dispatchToken = AppDispatcher.register(function(payload) {
   var action = payload.action;

--- a/src/main/resources/assets/javascripts/stores/RunStore.js
+++ b/src/main/resources/assets/javascripts/stores/RunStore.js
@@ -2,29 +2,25 @@
  * RunStore
  */
 
-var StoreDefaults   = require('./StoreDefaults');
+var BaseStore   = require('./BaseStore');
 var AppDispatcher   = require('../dispatchers/AppDispatcher');
 var RunConstants    = require('../constants/RunConstants');
 var RunActions      = require('../actions/RunActions');
 var RunApiUtils     = require('../utils/RunApiUtils');
 
-/* Store helpers */
-var EventEmitter  = require('events').EventEmitter;
-var assign        = require('object-assign');
-var _             = require('lodash');
-
-var RunStore = assign({}, StoreDefaults, EventEmitter.prototype, {
+class RunStoreClass extends BaseStore {
 
   // A custom comparator to sort (inverse) on the queryStarted param
   // @param obj {Object} the model
   // @return {Integer} the sorted model
-  comparator: function(model) {
+  comparator(model) {
+    debugger
     return -model.queryStarted;
-  },
+  }
 
   // Creates an SSE connection to the backend to make a real time stream
   // with the API
-  connect: function() {
+  connect() {
     this.close(); // Close any open connection
 
     // Create a new listener to the API endpoint
@@ -34,36 +30,38 @@ var RunStore = assign({}, StoreDefaults, EventEmitter.prototype, {
     this._eventSource.addEventListener('open', this.onOpen.bind(this));
     this._eventSource.addEventListener('error', this.onError.bind(this));
     this._eventSource.addEventListener('message', this.onMessage.bind(this));
-  },
+  }
 
   // Close the open SSE connect
-  close: function() {
+  close() {
     if (!!this._eventSource && this._eventSource.readyState) {
       this._eventSource.close();
     }
-  },
+  }
 
   // Yeah baby. We're ready to rambo! The SSEConnection has made a connection
   // to the API endpoint and now we should start getting updates (if any runs
   // are running of course).
-  onOpen: function() {
+  onOpen() {
     RunActions.onOpen();
-  },
+  }
 
   // The SSEConnection received an error. Notify the user about this error.
   // @param event {Object} the error object from the API
-  onError: function(event) {
+  onError(event) {
     RunActions.onError(event);
-  },
+  }
 
   // The SSEConnection has received a message from the API. We should notify
   // the application on this.
   // @param event {Object} the event object from the API
-  onMessage: function(event) {
+  onMessage(event) {
     var data = JSON.parse(event.data);
     RunActions.onMessage(data);
   }
-});
+}
+
+var RunStore = new RunStoreClass();
 
 RunStore.dispatchToken = AppDispatcher.register(function(payload) {
   var action = payload.action;

--- a/src/main/resources/assets/javascripts/stores/TableStore.js
+++ b/src/main/resources/assets/javascripts/stores/TableStore.js
@@ -2,14 +2,12 @@
  * TableStore
  */
 
-var StoreDefaults   = require('./StoreDefaults');
+var BaseStore   = require('./BaseStore');
 var AppDispatcher   = require('../dispatchers/AppDispatcher');
 var TableConstants  = require('../constants/TableConstants');
 var TableApiUtils   = require('../utils/TableApiUtils');
 
 /* Store helpers */
-var EventEmitter = require('events').EventEmitter;
-var assign = require('object-assign');
 var _ = require('lodash');
 var FQN = require('../utils/fqn');
 
@@ -83,37 +81,39 @@ function _markActive(name) {
   table.active = true;
 }
 
-var TableStore = assign({}, StoreDefaults, EventEmitter.prototype, {
+class TableStoreClass extends BaseStore {
 
   // Get the table by name
   // @param name {string} the table name
   // @return {object/undefined} the table object
-  getByName: function(name) {
-    if( _.isEmpty(_tables) ) return undefined;
+  getByName(name) {
+    if (_.isEmpty(_tables)) return undefined;
     return _.find(_tables, { name: name });
-  },
+  }
 
   // Alias for the getByName method
   // @param name {string} the table name
   // @return {object/undefined} the table object
-  get: function(name) {
-    if( _.isEmpty(_tables) ) return undefined;
+  get(name) {
+    if (_.isEmpty(_tables)) return undefined;
     return this.getByName(name);
-  },
+  }
 
   // Get the active table
   // @return {object/undefined} the active table
-  getActiveTable: function() {
-    if( _.isEmpty(_tables) ) return undefined;
+  getActiveTable() {
+    if (_.isEmpty(_tables)) return undefined;
     return _.find(_tables, { active: true });
-  },
+  }
 
   // Get all tables
   // @return {array} all the current tables
-  all: function() {
+  all() {
     return _tables;
   }
-});
+}
+
+var TableStore = new TableStoreClass();
 
 TableStore.dispatchToken = AppDispatcher.register(function(payload) {
   var action = payload.action;

--- a/src/main/resources/assets/javascripts/stores/UserStore.js
+++ b/src/main/resources/assets/javascripts/stores/UserStore.js
@@ -2,14 +2,11 @@
  * UserStore
  */
 
-var StoreDefaults   = require('./StoreDefaults');
+var BaseStore   = require('./BaseStore');
 var AppDispatcher  = require('../dispatchers/AppDispatcher');
 var UserConstants   = require('../constants/UserConstants');
 
-/* Store helpers */
-var EventEmitter  = require('events').EventEmitter;
-var assign        = require('object-assign');
-var _             = require('lodash');
+var _ = require('lodash');
 
 /**
  * User object
@@ -33,17 +30,17 @@ function _addUser(user) {
   _user = user;
 }
 
-var UserStore = assign({}, StoreDefaults, EventEmitter.prototype, {
-
+class UserStoreClass extends BaseStore {
   /**
    * Get the current user
    * @return {object} the user object
    */
-  getCurrentUser: function() {
+  getCurrentUser() {
     return _user;
   }
+}
 
-});
+var UserStore = new UserStoreClass();
 
 UserStore.dispatchToken = AppDispatcher.register(function(payload) {
   var action = payload.action;


### PR DESCRIPTION
Previously, `StoreDefaults` was a simple object that was mixed into each
individual store. This caused the issue that the `collection` property,
an array the holds records for each store, was shared between all
stores.

My proposed fix is to create a `BaseStore` class and have each store be
a singleton instance of a class that inherits from it.

I don't think this caused any regressions, but we'll have to smoke test
to make sure.

Plz to review @stefanvermaas @andykram 
