### PR TITLE
[fix-columns-info] Add partition tag to partitioned columns

### DIFF
--- a/src/main/resources/assets/javascripts/components/Column.js.jsx
+++ b/src/main/resources/assets/javascripts/components/Column.js.jsx
@@ -13,17 +13,14 @@ var Column = React.createClass({
   },
 
   render: function () {
-
-    // Define the output value
-    var value = this.props.partition ? '(Partition)' : '(' + this.props.type + ')';
-
     // Return the template
     return (
       <div className="col-sm-3">
         <div className="panel panel-default panel-compressed">
 
           <div className="panel-body">
-            <strong>{this.props.name} </strong> {value}
+            <strong>{this.props.name}</strong> ({this.props.type}) {
+              this.props.partition ? '(Partition)' : null}
           </div>
 
         </div>

--- a/src/main/resources/assets/javascripts/components/ColumnsPreview.js.jsx
+++ b/src/main/resources/assets/javascripts/components/ColumnsPreview.js.jsx
@@ -54,7 +54,7 @@ var ColumnsPreview = React.createClass({
           group = reuseGroup ? m[m.length - 1] : [],
           val;
 
-      group.push(<Column key={col.name} name={col.name} type={col.type} />);
+      group.push(<Column key={col.name} name={col.name} type={col.type} partition={col.partition} />);
 
       if (!reuseGroup) {
         m.push(group);


### PR DESCRIPTION
This PR adds `(Partition)` besides columns that are partition keys in the columns preview pane.

/cc @spikebrehm @stefanvermaas 
