### PR TITLE
[create-table][fix] Fixes create table functionality

### DIFF
--- a/reference.example.yml
+++ b/reference.example.yml
@@ -21,9 +21,6 @@ server:
 shiro:
   iniConfigs: ["classpath:shiro_allow_all.ini"]
 
-airpalHosts:
-  - http://127.0.0.1:8082
-
 dataSourceFactory:
   driverClass: com.mysql.jdbc.Driver
   user: MYSQL_USER

--- a/src/main/java/com/airbnb/airpal/AirpalConfiguration.java
+++ b/src/main/java/com/airbnb/airpal/AirpalConfiguration.java
@@ -13,7 +13,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
 import java.net.URI;
-import java.util.List;
 
 public class AirpalConfiguration extends Configuration
 {
@@ -76,8 +75,7 @@ public class AirpalConfiguration extends Configuration
     @Getter
     @Setter
     @JsonProperty
-    @NotNull
-    private List<URI> airpalHosts;
+    private String createTableDestinationSchema = "airpal";
 
     @Getter
     @Setter

--- a/src/main/java/com/airbnb/airpal/api/output/HiveTablePersistentOutput.java
+++ b/src/main/java/com/airbnb/airpal/api/output/HiveTablePersistentOutput.java
@@ -5,27 +5,39 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.UUID;
 
 import static java.lang.String.format;
 
+@Slf4j
 @JsonTypeName("hive")
 public class HiveTablePersistentOutput implements PersistentJobOutput
 {
     private final UUID jobUUID;
     private final String tmpTableName;
+    private final String destinationSchema;
 
     @Getter
     @Setter
     private URI location;
 
     public HiveTablePersistentOutput(UUID jobUUID,
-                                     String tmpTableName)
+                                     String tmpTableName,
+                                     String destinationSchema)
     {
         this.jobUUID = jobUUID;
         this.tmpTableName = tmpTableName;
+        try {
+            this.location = new URI(format("%s.%s", destinationSchema, tmpTableName));
+        }
+        catch (URISyntaxException e) {
+            log.error("Couldn't create hive output", e);
+        }
+        this.destinationSchema = destinationSchema;
     }
 
     @JsonCreator
@@ -33,7 +45,7 @@ public class HiveTablePersistentOutput implements PersistentJobOutput
                                      @JsonProperty("type") String type,
                                      @JsonProperty("description") String description)
     {
-        this((UUID) null, null);
+        this((UUID) null, null, null);
         this.location = location;
     }
 
@@ -52,7 +64,7 @@ public class HiveTablePersistentOutput implements PersistentJobOutput
     @Override
     public String processQuery(String query)
     {
-        String tableFqn = format("airpal.%s", tmpTableName);
+        String tableFqn = format("%s.%s", destinationSchema, tmpTableName);
         return format("CREATE TABLE %s AS %s", tableFqn, query);
     }
 }

--- a/src/main/java/com/airbnb/airpal/api/output/PersistentJobOutputFactory.java
+++ b/src/main/java/com/airbnb/airpal/api/output/PersistentJobOutputFactory.java
@@ -6,30 +6,29 @@ import com.google.inject.Inject;
 import com.google.inject.name.Named;
 
 import java.net.URI;
-import java.util.List;
 import java.util.UUID;
 
 public class PersistentJobOutputFactory
 {
     private final AmazonS3 s3Client;
-    private final List<URI> corsAllowedHosts;
     private final String s3Bucket;
+    private final String createTableDestinationSchema;
 
     @Inject
     public PersistentJobOutputFactory(AmazonS3 s3Client,
-                                      @Named("corsAllowedHosts") List<URI> corsAllowedHosts,
-                                      @Named("s3Bucket") String s3Bucket)
+            @Named("s3Bucket") String s3Bucket,
+            @Named("createTableDestinationSchema") String createTableDestinationSchema)
     {
         this.s3Client = s3Client;
-        this.corsAllowedHosts = corsAllowedHosts;
         this.s3Bucket = s3Bucket;
+        this.createTableDestinationSchema = createTableDestinationSchema;
     }
 
     public PersistentJobOutput create(final String tmpTable,
                                       final UUID jobUUID)
     {
         if (!Strings.isNullOrEmpty(tmpTable)) {
-            return new HiveTablePersistentOutput(jobUUID, tmpTable);
+            return new HiveTablePersistentOutput(jobUUID, tmpTable, createTableDestinationSchema);
         } else {
             return new CSVPersistentOutput(null, "csv", null);
         }

--- a/src/main/java/com/airbnb/airpal/api/output/builders/OutputBuilderFactory.java
+++ b/src/main/java/com/airbnb/airpal/api/output/builders/OutputBuilderFactory.java
@@ -2,6 +2,8 @@ package com.airbnb.airpal.api.output.builders;
 
 import com.airbnb.airpal.api.Job;
 import com.airbnb.airpal.api.output.PersistentJobOutput;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 import lombok.RequiredArgsConstructor;
 
 import java.io.IOException;
@@ -11,6 +13,8 @@ import static java.lang.String.format;
 @RequiredArgsConstructor
 public class OutputBuilderFactory
 {
+    private static final Splitter TABLE_SPLITTER = Splitter.on(".").omitEmptyStrings();
+
     private final long maxFileSizeBytes;
 
     public JobOutputBuilder forJob(Job job)
@@ -21,7 +25,8 @@ public class OutputBuilderFactory
             case "csv":
                 return new CsvOutputBuilder(true, job.getUuid(), maxFileSizeBytes);
             case "hive":
-                return new HiveTableOutputBuilder(job.getOutput().getLocation().toString().split(".")[1]);
+                return new HiveTableOutputBuilder(
+                        Iterables.getLast(TABLE_SPLITTER.splitToList(job.getOutput().getLocation().toString())));
             default:
                 throw new IllegalArgumentException(format("OutputBuilder for type %s not found", output.getType()));
         }

--- a/src/main/java/com/airbnb/airpal/api/output/persistors/HiveTablePersistor.java
+++ b/src/main/java/com/airbnb/airpal/api/output/persistors/HiveTablePersistor.java
@@ -1,18 +1,34 @@
 package com.airbnb.airpal.api.output.persistors;
 
 import com.airbnb.airpal.api.Job;
+import com.airbnb.airpal.api.output.PersistentJobOutput;
 import com.airbnb.airpal.api.output.builders.JobOutputBuilder;
 import com.airbnb.airpal.core.execution.QueryExecutionAuthorizer;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
 
 import java.net.URI;
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
 
 public class HiveTablePersistor
         implements Persistor
 {
+    private static final Splitter TABLE_SPLITTER = Splitter.on(".").omitEmptyStrings();
+    private final URI jobURI;
+
+    public HiveTablePersistor(PersistentJobOutput jobOutput)
+    {
+        this.jobURI = jobOutput.getLocation();
+    }
+
     @Override
     public boolean canPersist(QueryExecutionAuthorizer authorizer)
     {
-        return false;
+        List<String> locationParts = TABLE_SPLITTER.splitToList(jobURI.toString());
+        checkState(locationParts.size() == 2, "destination hive table did not have schema and table components");
+        return authorizer.isAuthorizedWrite("hive", Iterables.getFirst(locationParts, ""), Iterables.getLast(locationParts));
     }
 
     @Override

--- a/src/main/java/com/airbnb/airpal/api/output/persistors/PersistorFactory.java
+++ b/src/main/java/com/airbnb/airpal/api/output/persistors/PersistorFactory.java
@@ -15,7 +15,7 @@ public class PersistorFactory
             case "csv":
                 return csvPersistorFactory.getPersistor(job, jobOutput);
             case "hive":
-                return new HiveTablePersistor();
+                return new HiveTablePersistor(jobOutput);
             default:
                 throw new IllegalArgumentException();
         }

--- a/src/main/java/com/airbnb/airpal/modules/AirpalModule.java
+++ b/src/main/java/com/airbnb/airpal/modules/AirpalModule.java
@@ -49,7 +49,6 @@ import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
-import com.google.inject.TypeLiteral;
 import com.google.inject.name.Names;
 import io.airlift.configuration.ConfigurationFactory;
 import io.airlift.http.client.AsyncHttpClient;
@@ -66,7 +65,6 @@ import javax.inject.Named;
 
 import java.net.URI;
 import java.util.Collections;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -99,7 +97,7 @@ public class AirpalModule extends AbstractModule
         bind(FilesResource.class).in(Scopes.SINGLETON);
 
         bind(EnvironmentLoaderListener.class).in(Scopes.SINGLETON);
-        bind(new TypeLiteral<List<URI>>(){}).annotatedWith(Names.named("corsAllowedHosts")).toInstance(config.getAirpalHosts());
+        bind(String.class).annotatedWith(Names.named("createTableDestinationSchema")).toInstance(config.getCreateTableDestinationSchema());
         bind(String.class).annotatedWith(Names.named("s3Bucket")).toInstance(Strings.nullToEmpty(config.getS3Bucket()));
 
         bind(PrestoHealthCheck.class).in(Scopes.SINGLETON);

--- a/src/main/resources/assets/gulp/tasks/watch.js
+++ b/src/main/resources/assets/gulp/tasks/watch.js
@@ -4,4 +4,4 @@
 */
 
 var gulp  = require('gulp');
-gulp.task('watch', ['setWatch', 'browserSync']);
+gulp.task('watch', ['setWatch',]);

--- a/src/main/resources/assets/javascripts/components/RunsTable.jsx
+++ b/src/main/resources/assets/javascripts/components/RunsTable.jsx
@@ -201,12 +201,18 @@ let CellRenderers = {
     let currentUser = rowData._currentUser;
     let killable = currentUser && currentUser === run.user;
     let output = cellData;
-    if (output && output.location) {
-      return (
-        <a href={output.location} target="_blank">
-          Download CSV
-        </a>
-      );
+    if (output && output.location && (run.state !== 'FAILED')) {
+      if (output.location.indexOf('http') != -1) {
+        return (
+          <a href={output.location} target="_blank">
+            Download CSV
+          </a>
+        );
+      } else {
+        return (
+          <span>{output.location}</span>
+        );
+      }
     } else if (run.state === 'RUNNING') {
       return (
         <div className={cx({

--- a/src/main/resources/assets/javascripts/utils/RunApiUtils.js
+++ b/src/main/resources/assets/javascripts/utils/RunApiUtils.js
@@ -14,7 +14,7 @@ export default {
   },
 
   fetchForUser(user) {
-    return xhr(`/api/users/${user.name}/active-queries`).then(checkResults);
+    return xhr(`/api/users/${user.name}/queries`).then(checkResults);
   },
 
   fetchHistory() {


### PR DESCRIPTION
This PR does the following things:
- Fixes the `CREATE TABLE` functionality of Airpal
- Makes the destination Hive database for `CREATE TABLE` configurable
- Removes unused `airpalHosts` configuration
- Fixes the display of the `Output` column based on query status and output type
