### PR TITLE
[fix-delete-saved-query] Fixes saved query deletion

### DIFF
--- a/src/main/resources/assets/gulp/tasks/watch.js
+++ b/src/main/resources/assets/gulp/tasks/watch.js
@@ -4,4 +4,4 @@
 */
 
 var gulp  = require('gulp');
-gulp.task('watch', ['setWatch',]);
+gulp.task('watch', ['setWatch', 'browserSync']);

--- a/src/main/resources/assets/javascripts/components/RunsTable.jsx
+++ b/src/main/resources/assets/javascripts/components/RunsTable.jsx
@@ -202,7 +202,7 @@ let CellRenderers = {
     let killable = currentUser && currentUser === run.user;
     let output = cellData;
     if (output && output.location && (run.state !== 'FAILED')) {
-      if (output.location.indexOf('http') != -1) {
+      if (output.location[0] === '/' || output.location.indexOf('http') != -1) {
         return (
           <a href={output.location} target="_blank">
             Download CSV

--- a/src/main/resources/assets/javascripts/utils/xhr.js
+++ b/src/main/resources/assets/javascripts/utils/xhr.js
@@ -7,7 +7,11 @@ const status = (response) => {
 };
 
 const json = (response) => {
-  return response.json();
+  if (response.status !== 204) {
+    return response.json();
+  } else {
+    return {};
+  }
 };
 
 const xhr = (url, params = {}) => {


### PR DESCRIPTION
This PR does the following:
1. Fixes saved query deletion by patching `json(response)` in `utils/xhr.js`
2. Fixes download links if using the local FS store
3. Restores the awful browserSync task to gulp, since I don't want to figure out how to make gulp keep watching without it
