### PR TITLE
Add a tarball gradle task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,29 @@ task buildAssets(type: NodeTask) {
     }
 }
 
+task buildTar(type: Tar) {
+  baseName = project.name
+  compression = Compression.GZIP
+  extension = "tar.gz"
+
+  into("$baseName-$version/lib") {
+    from jar.archivePath
+    from configurations.runtime
+  }
+
+  into("$baseName-$version/bin") {
+    from "scripts/airpal"
+    fileMode 0755
+  }
+
+  into("$baseName-$version") {
+    from "reference.example.yml"
+    rename { String fileName ->
+      fileName.replace('example.', '')
+    }
+  }
+}
+
 shadowJar {
     transform(com.github.jengelman.gradle.plugins.shadow.transformers.ServiceFileTransformer)
     exclude 'META-INF/*.DSA'
@@ -124,4 +147,5 @@ shadowJar {
 
 buildAssets.dependsOn installAssets
 compileJava.dependsOn buildAssets
+buildTar.dependsOn jar
 clean.dependsOn cleanAssets

--- a/scripts/airpal
+++ b/scripts/airpal
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd $(dirname $0)/..
+exec java -Duser.timezone=UTC -cp "lib/*" com.airbnb.airpal.AirpalApplication "$@"


### PR DESCRIPTION
Hi!

I don't really know what I'm doing with gradle, but this might be useful to create a dist tarball. 

If this looks interesting to you folks, I can also add a `.travis.yml` to automatically create these and add them to your github releases page. We do this with [Sequins][0] ([travis.yml][1]) and it works super super well. Having downloadable tarballs is essential to getting people to use your thing, imo.

[0]:  https://github.com/stripe/sequins
[1]: https://github.com/stripe/sequins/blob/master/.travis.yml#L5-L14