### PR TITLE
Updated browser-sync in package.json

### DIFF
--- a/src/main/resources/assets/package.json
+++ b/src/main/resources/assets/package.json
@@ -59,6 +59,7 @@
   "dependencies": {
     "alt": "^0.14.3",
     "brace": "^0.4.0",
+    "browser-sync": "^2.7.13",
     "es6-shim": "^0.25.3",
     "fixed-data-table": "^0.1.0",
     "jquery": "~1.9.0",


### PR DESCRIPTION
+ Updated browser-sync from "~1.3.6"  to "^2.7.13"
+ TypeError: Cannot read property 'prototype' of undefined on this line of code
+ Error within 
```
airpal/src/main/resources/assets/node_modules/browser-sync/node_modules/http-proxy/lib/http-proxy/index.js:108:17)
```
