### PR TITLE
Update some of the build toolchain

### DIFF
--- a/src/main/resources/assets/package.json
+++ b/src/main/resources/assets/package.json
@@ -41,8 +41,8 @@
   "devDependencies": {
     "babel-jest": "^4.0.0",
     "babelify": "^5.0.3",
-    "browserify": "~5.10.1",
-    "browserify-shim": "~3.7.0",
+    "browserify": "~13.0.0",
+    "browserify-shim": "~3.8.12",
     "gulp": "^3.8.7",
     "gulp-changed": "^0.4.1",
     "gulp-notify": "^1.4.2",
@@ -53,7 +53,7 @@
     "react-tools": "~0.12",
     "require-dir": "^0.1.0",
     "vinyl-source-stream": "~0.1.1",
-    "watchify": "~1.0.2"
+    "watchify": "~3.7.0"
   },
   "dependencies": {
     "alt": "^0.14.3",


### PR DESCRIPTION
I am seeing `fsevents` failures (because of its old version) on newer `node` (i.e. `5.3`), and with some upgrades on build toolchain the failures will go away.
