### PR TITLE
S3 cse encryption and compression

### DIFF
--- a/src/main/java/com/airbnb/airpal/AirpalConfiguration.java
+++ b/src/main/java/com/airbnb/airpal/AirpalConfiguration.java
@@ -75,6 +75,11 @@ public class AirpalConfiguration extends Configuration
     @Getter
     @Setter
     @JsonProperty
+    private String s3EncryptionMaterialsProvider;
+
+    @Getter
+    @Setter
+    @JsonProperty
     private String createTableDestinationSchema = "airpal";
 
     @Getter
@@ -107,4 +112,11 @@ public class AirpalConfiguration extends Configuration
     @JsonProperty
     @NotNull
     private boolean useS3 = false;
+
+    @Getter
+    @Setter
+    @Valid
+    @JsonProperty
+    @NotNull
+    private boolean compressedOutput = false;
 }

--- a/src/main/java/com/airbnb/airpal/api/output/builders/CsvOutputBuilder.java
+++ b/src/main/java/com/airbnb/airpal/api/output/builders/CsvOutputBuilder.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.util.List;
 import java.util.UUID;
+import java.util.zip.GZIPOutputStream;
 
 @Slf4j
 public class CsvOutputBuilder implements JobOutputBuilder
@@ -34,13 +35,13 @@ public class CsvOutputBuilder implements JobOutputBuilder
     @JsonIgnore
     private final UUID jobUUID;
 
-    public CsvOutputBuilder(boolean includeHeader, UUID jobUUID, long maxFileSizeBytes) throws IOException {
+    public CsvOutputBuilder(boolean includeHeader, UUID jobUUID, long maxFileSizeBytes, boolean compressedOutput) throws IOException {
         this.includeHeader = includeHeader;
         this.jobUUID = jobUUID;
         this.outputFile = File.createTempFile(jobUUID.toString(), FILE_SUFFIX);
         this.maxFileSizeBytes = maxFileSizeBytes;
         this.countingOutputStream = new CountingOutputStream(new FileOutputStream(this.outputFile));
-        this.csvWriter = new CSVWriter(new OutputStreamWriter(this.countingOutputStream));
+        this.csvWriter = new CSVWriter(new OutputStreamWriter(compressedOutput ? new GZIPOutputStream(this.countingOutputStream) : this.countingOutputStream));
     }
 
     @Override

--- a/src/main/java/com/airbnb/airpal/api/output/builders/CsvOutputBuilder.java
+++ b/src/main/java/com/airbnb/airpal/api/output/builders/CsvOutputBuilder.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.util.List;
 import java.util.UUID;
@@ -41,7 +42,14 @@ public class CsvOutputBuilder implements JobOutputBuilder
         this.outputFile = File.createTempFile(jobUUID.toString(), FILE_SUFFIX);
         this.maxFileSizeBytes = maxFileSizeBytes;
         this.countingOutputStream = new CountingOutputStream(new FileOutputStream(this.outputFile));
-        this.csvWriter = new CSVWriter(new OutputStreamWriter(compressedOutput ? new GZIPOutputStream(this.countingOutputStream) : this.countingOutputStream));
+        OutputStreamWriter writer;
+        if (compressedOutput) {
+            writer = new OutputStreamWriter(new GZIPOutputStream(this.countingOutputStream));
+        }
+        else {
+            writer = new OutputStreamWriter(this.countingOutputStream);
+        }
+        this.csvWriter = new CSVWriter(writer);
     }
 
     @Override

--- a/src/main/java/com/airbnb/airpal/api/output/builders/OutputBuilderFactory.java
+++ b/src/main/java/com/airbnb/airpal/api/output/builders/OutputBuilderFactory.java
@@ -15,6 +15,7 @@ import static java.lang.String.format;
 public class OutputBuilderFactory
 {
     private final long maxFileSizeBytes;
+    private final boolean isCompressedOutput;
 
     public JobOutputBuilder forJob(Job job)
             throws IOException, InvalidQueryException
@@ -22,7 +23,7 @@ public class OutputBuilderFactory
         PersistentJobOutput output = job.getOutput();
         switch (output.getType()) {
             case "csv":
-                return new CsvOutputBuilder(true, job.getUuid(), maxFileSizeBytes);
+                return new CsvOutputBuilder(true, job.getUuid(), maxFileSizeBytes, isCompressedOutput);
             case "hive":
                 HiveTablePersistentOutput hiveOutput = (HiveTablePersistentOutput) output;
                 URI location = output.getLocation();

--- a/src/main/java/com/airbnb/airpal/api/output/persistors/CSVPersistorFactory.java
+++ b/src/main/java/com/airbnb/airpal/api/output/persistors/CSVPersistorFactory.java
@@ -13,12 +13,13 @@ public class CSVPersistorFactory
     private AmazonS3 s3Client;
     private String s3Bucket;
     private ExpiringFileStore expiringFileStore;
+    private boolean compressedOutput;
 
     public Persistor getPersistor(Job job, PersistentJobOutput jobOutput)
     {
         // TODO: Support variable CSV persistor.
         if (useS3Persistor) {
-            return new S3FilePersistor(s3Client, s3Bucket, 0L);
+            return new S3FilePersistor(s3Client, s3Bucket, 0L, compressedOutput);
         } else {
             return new FlatFilePersistor(expiringFileStore);
         }

--- a/src/main/java/com/airbnb/airpal/api/output/persistors/S3FilePersistor.java
+++ b/src/main/java/com/airbnb/airpal/api/output/persistors/S3FilePersistor.java
@@ -25,6 +25,7 @@ public class S3FilePersistor
     private final AmazonS3 s3Client;
     private final String outputBucket;
     private final long maxSizeForTextView;
+    private final boolean compressedOutput;
 
     @Override
     public boolean canPersist(QueryExecutionAuthorizer authorizer)
@@ -46,6 +47,9 @@ public class S3FilePersistor
         val objectMetaData = new ObjectMetadata();
         objectMetaData.setContentLength(file.length());
         objectMetaData.setContentType(MediaType.CSV_UTF_8.toString());
+        if (compressedOutput) {
+            objectMetaData.setContentEncoding("gzip");
+        }
 
         val putRequest = new PutObjectRequest(
                 outputBucket,

--- a/src/main/java/com/airbnb/airpal/resources/S3FilesResource.java
+++ b/src/main/java/com/airbnb/airpal/resources/S3FilesResource.java
@@ -2,6 +2,7 @@ package com.airbnb.airpal.resources;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.google.common.io.ByteStreams;
 import com.google.inject.Inject;
 import lombok.val;
@@ -52,7 +53,12 @@ public class S3FilesResource
         if (object == null) {
             return Response.status(Response.Status.NOT_FOUND).build();
         } else {
-            return Response.ok(new StreamingOutput() {
+            ObjectMetadata objectMetadata = object.getObjectMetadata();
+            Response.ResponseBuilder builder = Response.ok().type(objectMetadata.getContentType());
+            if (objectMetadata.getContentEncoding() != null) {
+                builder = builder.encoding(objectMetadata.getContentEncoding()); // gzip
+            }
+            return builder.entity(new StreamingOutput() {
                 @Override
                 public void write(OutputStream output)
                         throws IOException, WebApplicationException


### PR DESCRIPTION
This change adds support for gzip compression on data stored in S3 to reduce storage size.

This change also adds support for S3 encryption materials provider implementations when dealing with data in S3.  This allows for client-managed encryption keys which are still transparently used when viewing/downloading output files stored in S3.