### PR TITLE
Change default presto user

### DIFF
--- a/src/main/java/com/airbnb/airpal/AirpalConfiguration.java
+++ b/src/main/java/com/airbnb/airpal/AirpalConfiguration.java
@@ -26,7 +26,7 @@ public class AirpalConfiguration extends Configuration
     @Setter
     @JsonProperty
     @NotNull
-    private String prestoUser = "andykram";
+    private String prestoUser = "airpalChangeMe";
 
     @Getter
     @Setter


### PR DESCRIPTION
By default airpal used my personal handle of andykram when issuing queries against presto. This is confusing when people look at their presto query logs, so this PR  changes it from my personal handle to `airpalChangeMe`, hopefully lowering the amount of confusion caused.