### PR TITLE
[airpal] - Correcting ORDER BY condition for MySQL usage query

### DIFF
--- a/src/main/java/com/airbnb/airpal/core/store/usage/SQLUsageStore.java
+++ b/src/main/java/com/airbnb/airpal/core/store/usage/SQLUsageStore.java
@@ -47,14 +47,14 @@ public class SQLUsageStore implements UsageStore
     {
         try (Handle handle = dbi.open()) {
             Query<Map<String, Object>> query = handle.createQuery(
-                    "SELECT COUNT(*) AS count, connector_id AS connectorId, schema_ AS \"schema\", table_ AS \"table\" " +
+                    "SELECT connector_id AS connectorId, schema_ AS \"schema\", table_ AS \"table\", COUNT(*) AS count " +
                             "FROM jobs j " +
                             "LEFT OUTER JOIN job_tables jt ON j.id = jt.job_id " +
                             "LEFT OUTER JOIN tables t ON jt.table_id = t.id " +
                             "WHERE " + Util.getQueryFinishedCondition(dbType) + " " +
                             "AND (" + Util.getTableCondition(Lists.newArrayList(tables)) + ") " +
                             "GROUP BY connector_id, schema_, table_ " +
-                            "ORDER BY query_finished DESC")
+                            "ORDER BY count DESC")
                     .bind("day_interval", 1);
 
             return query.


### PR DESCRIPTION
This PR resolves issue #174 which surfaced when running in MySQL 5.7.5 where ONLY_FULL_GROUP_BY is enabled by default. The problem was that query_finished was not included in the GROUP BY clause causing the query to fail. Digging further it was revealed that the ORDER BY condition should be by COUNT(*) rather than query_finished which is meaningless in this context.

Additionally moved the COUNT(*) to the end of the SELECT condition for readability. 

to: @bkyryliuk 

Tested by ensuring that the errors were no longer being logged to the console. 